### PR TITLE
feat: ファンディングレート取得をBTC・ETH全期間対応に拡張

### DIFF
--- a/backend/app/core/services/funding_rate_service.py
+++ b/backend/app/core/services/funding_rate_service.py
@@ -33,17 +33,17 @@ class BybitFundingRateService:
     def normalize_symbol(self, symbol: str) -> str:
         """
         シンボルを正規化（無期限契約形式に変換）
-        
+
         Args:
             symbol: 入力シンボル（例: 'BTC/USDT' または 'BTC/USDT:USDT'）
-            
+
         Returns:
             正規化されたシンボル（例: 'BTC/USDT:USDT'）
         """
         # 既に無期限契約形式の場合はそのまま返す
         if ':' in symbol:
             return symbol
-            
+
         # スポット形式を無期限契約形式に変換
         if symbol.endswith('/USDT'):
             return f"{symbol}:USDT"
@@ -57,20 +57,20 @@ class BybitFundingRateService:
         """パラメータの検証"""
         if not symbol:
             raise ValueError("シンボルが指定されていません")
-        
+
         if limit <= 0 or limit > 1000:
             raise ValueError("limitは1-1000の範囲で指定してください")
 
     async def fetch_current_funding_rate(self, symbol: str) -> Dict[str, Any]:
         """
         現在のファンディングレートを取得
-        
+
         Args:
             symbol: 取引ペアシンボル（例: 'BTC/USDT'）
-            
+
         Returns:
             現在のファンディングレートデータ
-            
+
         Raises:
             ValueError: パラメータが無効な場合
             ccxt.NetworkError: ネットワークエラーの場合
@@ -78,20 +78,20 @@ class BybitFundingRateService:
         """
         # シンボルの正規化
         normalized_symbol = self.normalize_symbol(symbol)
-        
+
         try:
             logger.info(f"現在のファンディングレートを取得中: {normalized_symbol}")
-            
+
             # 非同期でファンディングレートを取得
             funding_rate = await asyncio.get_event_loop().run_in_executor(
                 None,
                 self.exchange.fetch_funding_rate,
                 normalized_symbol
             )
-            
+
             logger.info(f"現在のファンディングレート取得成功: {normalized_symbol}")
             return funding_rate
-            
+
         except ccxt.BadSymbol as e:
             logger.error(f"無効なシンボル: {normalized_symbol}")
             raise ccxt.BadSymbol(f"無効なシンボル: {normalized_symbol}") from e
@@ -106,22 +106,22 @@ class BybitFundingRateService:
             raise ccxt.ExchangeError(f"ファンディングレート取得中にエラーが発生しました: {e}") from e
 
     async def fetch_funding_rate_history(
-        self, 
-        symbol: str, 
+        self,
+        symbol: str,
         limit: int = 100,
         since: Optional[int] = None
     ) -> List[Dict[str, Any]]:
         """
         ファンディングレート履歴を取得
-        
+
         Args:
             symbol: 取引ペアシンボル（例: 'BTC/USDT'）
             limit: 取得するデータ数（1-1000）
             since: 開始タイムスタンプ（ミリ秒）
-            
+
         Returns:
             ファンディングレート履歴データのリスト
-            
+
         Raises:
             ValueError: パラメータが無効な場合
             ccxt.NetworkError: ネットワークエラーの場合
@@ -129,13 +129,13 @@ class BybitFundingRateService:
         """
         # パラメータの検証
         self._validate_parameters(symbol, limit)
-        
+
         # シンボルの正規化
         normalized_symbol = self.normalize_symbol(symbol)
-        
+
         try:
             logger.info(f"ファンディングレート履歴を取得中: {normalized_symbol}, limit={limit}")
-            
+
             # 非同期でファンディングレート履歴を取得
             funding_history = await asyncio.get_event_loop().run_in_executor(
                 None,
@@ -144,10 +144,87 @@ class BybitFundingRateService:
                 since,
                 limit
             )
-            
+
             logger.info(f"ファンディングレート履歴取得成功: {len(funding_history)}件")
             return funding_history
-            
+
+        except ccxt.BadSymbol as e:
+            logger.error(f"無効なシンボル: {normalized_symbol}")
+            raise ccxt.BadSymbol(f"無効なシンボル: {normalized_symbol}") from e
+        except ccxt.NetworkError as e:
+            logger.error(f"ネットワークエラー: {e}")
+            raise
+        except ccxt.ExchangeError as e:
+            logger.error(f"取引所エラー: {e}")
+            raise
+        except Exception as e:
+            logger.error(f"予期しないエラー: {e}")
+            raise ccxt.ExchangeError(f"ファンディングレート履歴取得中にエラーが発生しました: {e}") from e
+
+    async def fetch_all_funding_rate_history(
+        self,
+        symbol: str
+    ) -> List[Dict[str, Any]]:
+        """
+        全期間のファンディングレート履歴を取得
+
+        Args:
+            symbol: 取引ペアシンボル（例: 'BTC/USDT'）
+
+        Returns:
+            全期間のファンディングレート履歴データのリスト
+
+        Raises:
+            ValueError: パラメータが無効な場合
+            ccxt.NetworkError: ネットワークエラーの場合
+            ccxt.ExchangeError: 取引所エラーの場合
+        """
+        # シンボルの正規化
+        normalized_symbol = self.normalize_symbol(symbol)
+
+        try:
+            logger.info(f"全期間のファンディングレート履歴を取得中: {normalized_symbol}")
+
+            all_funding_history = []
+            since = None  # 最古のデータから開始
+            page_limit = 1000  # Bybitの最大制限
+
+            while True:
+                # ページごとにデータを取得
+                funding_history = await asyncio.get_event_loop().run_in_executor(
+                    None,
+                    self.exchange.fetch_funding_rate_history,
+                    normalized_symbol,
+                    since,
+                    page_limit
+                )
+
+                if not funding_history:
+                    # データがない場合は終了
+                    break
+
+                logger.info(f"取得: {len(funding_history)}件 (累計: {len(all_funding_history) + len(funding_history)}件)")
+
+                # 重複チェック（タイムスタンプベース）
+                existing_timestamps = {item['timestamp'] for item in all_funding_history}
+                new_items = [item for item in funding_history if item['timestamp'] not in existing_timestamps]
+
+                all_funding_history.extend(new_items)
+
+                # 次のページの開始点を設定
+                if len(funding_history) < page_limit:
+                    # 取得件数が制限未満の場合は最後のページ
+                    break
+
+                # 最後のアイテムのタイムスタンプの次から開始
+                since = funding_history[-1]['timestamp'] + 1
+
+                # レート制限対応
+                await asyncio.sleep(0.1)
+
+            logger.info(f"全期間のファンディングレート履歴取得完了: {len(all_funding_history)}件")
+            return all_funding_history
+
         except ccxt.BadSymbol as e:
             logger.error(f"無効なシンボル: {normalized_symbol}")
             raise ccxt.BadSymbol(f"無効なシンボル: {normalized_symbol}") from e
@@ -164,28 +241,33 @@ class BybitFundingRateService:
     async def fetch_and_save_funding_rate_data(
         self,
         symbol: str,
-        limit: int = 100,
+        limit: Optional[int] = None,
         repository: Optional[FundingRateRepository] = None,
+        fetch_all: bool = False,
     ) -> dict:
         """
         ファンディングレートデータを取得してデータベースに保存
-        
+
         Args:
             symbol: 取引ペアシンボル（例: 'BTC/USDT'）
-            limit: 取得するデータ数（1-1000）
+            limit: 取得するデータ数（1-1000、fetch_all=Trueの場合は無視）
             repository: ファンディングレートリポジトリ（テスト用）
-            
+            fetch_all: 全期間のデータを取得するかどうか
+
         Returns:
             保存結果を含む辞書
-            
+
         Raises:
             ValueError: パラメータが無効な場合
             Exception: データベースエラーの場合
         """
         try:
             # ファンディングレート履歴を取得
-            funding_history = await self.fetch_funding_rate_history(symbol, limit)
-            
+            if fetch_all:
+                funding_history = await self.fetch_all_funding_rate_history(symbol)
+            else:
+                funding_history = await self.fetch_funding_rate_history(symbol, limit or 100)
+
             # データベースに保存
             if repository is None:
                 # 実際のデータベースセッションを使用
@@ -204,14 +286,14 @@ class BybitFundingRateService:
                 saved_count = await self._save_funding_rate_to_database(
                     funding_history, symbol, repository
                 )
-            
+
             return {
                 "symbol": symbol,
                 "fetched_count": len(funding_history),
                 "saved_count": saved_count,
                 "success": True,
             }
-            
+
         except Exception as e:
             logger.error(f"ファンディングレートデータ取得・保存エラー: {e}")
             raise
@@ -224,12 +306,12 @@ class BybitFundingRateService:
     ) -> int:
         """
         ファンディングレートデータをデータベースに保存（内部メソッド）
-        
+
         Args:
             funding_history: ファンディングレート履歴データ
             symbol: 取引ペアシンボル
             repository: ファンディングレートリポジトリ
-            
+
         Returns:
             保存された件数
         """
@@ -240,10 +322,10 @@ class BybitFundingRateService:
             funding_timestamp = datetime.fromtimestamp(
                 rate_data['timestamp'] / 1000, tz=timezone.utc
             )
-            
+
             # データ取得時刻
             current_timestamp = datetime.now(timezone.utc)
-            
+
             record = {
                 "symbol": self.normalize_symbol(symbol),
                 "funding_rate": float(rate_data['fundingRate']),
@@ -254,6 +336,6 @@ class BybitFundingRateService:
                 "index_price": None,  # 履歴データには含まれない場合がある
             }
             records.append(record)
-        
+
         # データベースに挿入
         return repository.insert_funding_rate_data(records)

--- a/frontend/components/FundingRateCollectionButton.tsx
+++ b/frontend/components/FundingRateCollectionButton.tsx
@@ -59,8 +59,8 @@ const FundingRateCollectionButton: React.FC<
     FundingRateCollectionResult | BulkFundingRateCollectionResult | null
   >(null);
 
-  // BTCの無期限契約シンボル（USDTのみ）
-  const supportedSymbols = ["BTC/USDT:USDT"];
+  // BTC・ETHの無期限契約シンボル（USDTのみ）
+  const supportedSymbols = ["BTC/USDT:USDT", "ETH/USDT:USDT"];
 
   /**
    * ファンディングレートデータを収集
@@ -69,8 +69,8 @@ const FundingRateCollectionButton: React.FC<
     if (mode === "bulk") {
       // 確認ダイアログ
       const confirmed = window.confirm(
-        `BTCのファンディングレートデータを取得します。\n\n` +
-          "この処理には時間がかかる場合があります。続行しますか？"
+        `BTC・ETHの全期間ファンディングレートデータを取得します。\n\n` +
+          "この処理には数分かかる場合があります。続行しますか？"
       );
 
       if (!confirmed) {
@@ -87,7 +87,7 @@ const FundingRateCollectionButton: React.FC<
 
       if (mode === "bulk") {
         // 一括収集
-        apiUrl = "/api/data/funding-rates/bulk";
+        apiUrl = "/api/data/funding-rates/bulk-collect";
         requestOptions = {
           method: "POST",
           headers: {
@@ -95,10 +95,10 @@ const FundingRateCollectionButton: React.FC<
           },
         };
       } else {
-        // 単一収集
+        // 単一収集（全期間取得）
         apiUrl = `/api/data/funding-rates/collect?symbol=${encodeURIComponent(
           symbol
-        )}&limit=100`;
+        )}&fetch_all=true`;
         requestOptions = {
           method: "POST",
           headers: {
@@ -162,7 +162,7 @@ const FundingRateCollectionButton: React.FC<
         return "エラーが発生しました";
       default:
         return mode === "bulk"
-          ? "BTCファンディングレート収集・保存"
+          ? "BTC・ETHファンディングレート収集・保存"
           : "ファンディングレート収集・保存";
     }
   };
@@ -257,7 +257,7 @@ const FundingRateCollectionButton: React.FC<
         className={getButtonClasses()}
         title={
           mode === "bulk"
-            ? `BTCのファンディングレートデータを収集・保存`
+            ? `BTC・ETHの全期間ファンディングレートデータを収集・保存`
             : `${symbol}のファンディングレートデータを収集・保存`
         }
       >
@@ -269,7 +269,7 @@ const FundingRateCollectionButton: React.FC<
       <div className="text-xs text-secondary-500 dark:text-secondary-500">
         {mode === "bulk" ? (
           <>
-            BTCのファンディングレートデータを
+            BTC・ETHの全期間ファンディングレートデータを
             <br />
             取得・保存します
           </>


### PR DESCRIPTION
## 概要
ファンディングレート取得機能を拡張し、BTCだけでなくETHも対象に追加し、100件制限を撤廃して全期間のデータを取得できるようにしました。

## 変更内容

### 🚀 新機能
- **ETH対応**: BTC/USDT:USDTに加えてETH/USDT:USDTも取得対象に追加
- **全期間取得**: 100件制限を撤廃し、ページネーションで全期間のデータを取得
- **重複チェック**: タイムスタンプベースで重複データを自動除外
- **レート制限対応**: API呼び出し間隔を調整してレート制限を回避

### 🔧 技術的改善
- `fetch_all_funding_rate_history`メソッドを新規追加
- ページネーション機能で1000件ずつ効率的に取得
- エラーハンドリングの強化（個別シンボル失敗の分離）
- 進捗ログの詳細化

### 🎨 UI/UX改善
- ボタンテキストを「BTC・ETHファンディングレート収集・保存」に更新
- 確認ダイアログで「数分かかる場合があります」と適切な時間を表示
- ツールチップとヘルプテキストをBTC・ETH対応に更新

## 変更ファイル
- `backend/app/core/services/funding_rate_service.py` - 全期間取得メソッド追加
- `backend/app/api/funding_rates.py` - ETH追加、全期間取得対応、APIドキュメント更新
- `frontend/components/FundingRateCollectionButton.tsx` - UI表示更新、APIパス修正

## テスト
- [ ] BTC・ETHの一括収集が正常に動作することを確認
- [ ] 全期間データ取得が正常に動作することを確認
- [ ] 重複データが適切に除外されることを確認
- [ ] エラーハンドリングが適切に動作することを確認

## 注意事項
- 全期間取得は大量のAPIコールを伴うため、処理時間が数分かかる場合があります
- Bybitのレート制限に配慮し、リクエスト間隔を0.1秒に設定しています
- 既存のデータとの重複は自動的に除外されます

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author