### PR TITLE
docs: 変動率カラム削除に関するコメントを追加

### DIFF
--- a/frontend/components/OHLCVDataTable.tsx
+++ b/frontend/components/OHLCVDataTable.tsx
@@ -98,6 +98,7 @@ const OHLCVDataTable: React.FC<OHLCVDataTableProps> = ({
   className = "",
 }) => {
   // テーブルカラムの定義
+  // 注意: 変動率カラムは計算機能未実装のため一時的に削除済み
   const columns: TableColumn<PriceData>[] = [
     {
       key: "timestamp",


### PR DESCRIPTION
## 📋 概要

変動率カラムの削除に関する説明コメントを追加しました。

## 🎯 目的

- コードの可読性向上
- 変動率カラムが削除された理由の明確化
- 将来的な再実装の意図を示す

## 🔧 変更内容

### 追加したもの
- `frontend/components/OHLCVDataTable.tsx` にコメントを追加
- 変動率カラムが計算機能未実装のため一時的に削除されていることを明記

### 変更箇所
```typescript
// テーブルカラムの定義
// 注意: 変動率カラムは計算機能未実装のため一時的に削除済み
const columns: TableColumn<PriceData>[] = [
```

## 📊 背景

前回のコミット（81f4f97）で変動率カラムを削除しましたが、削除理由がコード上で明確でなかったため、説明コメントを追加しました。

## 🔮 今後の予定

- バックエンドでの変動率計算機能実装
- 計算機能完成後、このカラムを再追加
- より正確で効率的な変動率表示の実現

## ✅ チェックリスト

- [x] 説明コメントの追加
- [x] コードの可読性向上
- [x] 削除理由の明確化
- [x] 将来の実装意図の記載

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author