### PR TITLE
feat: Improve backtest page layout with side-by-side display

### DIFF
--- a/frontend/app/backtest/page.tsx
+++ b/frontend/app/backtest/page.tsx
@@ -62,7 +62,6 @@ interface BacktestResult {
 }
 
 export default function BacktestPage() {
-  const [activeTab, setActiveTab] = useState<"form" | "results">("form");
   const [latestResult, setLatestResult] = useState<BacktestResult | null>(null);
   const [results, setResults] = useState<BacktestResult[]>([]);
   const [selectedResult, setSelectedResult] = useState<BacktestResult | null>(
@@ -98,7 +97,6 @@ export default function BacktestPage() {
       body: config,
       onSuccess: (data) => {
         setLatestResult(data.result);
-        setActiveTab("results");
         loadResults(); // 結果一覧を更新
       },
       onError: (error) => {
@@ -142,92 +140,61 @@ export default function BacktestPage() {
           </p>
         </div>
 
-        {/* タブナビゲーション */}
-        <div className="mb-6">
-          <div className="border-b border-gray-700">
-            <nav className="-mb-px flex space-x-8">
-              <button
-                onClick={() => setActiveTab("form")}
-                className={`py-2 px-1 border-b-2 font-medium text-sm ${
-                  activeTab === "form"
-                    ? "border-blue-500 text-blue-400"
-                    : "border-transparent text-gray-400 hover:text-gray-300 hover:border-gray-300"
-                }`}
-              >
-                バックテスト設定
-              </button>
-              <button
-                onClick={() => setActiveTab("results")}
-                className={`py-2 px-1 border-b-2 font-medium text-sm ${
-                  activeTab === "results"
-                    ? "border-blue-500 text-blue-400"
-                    : "border-transparent text-gray-400 hover:text-gray-300 hover:border-gray-300"
-                }`}
-              >
-                結果一覧
-              </button>
-            </nav>
+        {/* メインコンテンツ - 2カラムレイアウト */}
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+          {/* 左側: バックテスト設定フォーム */}
+          <div className="space-y-6">
+            <div className="bg-gray-800 rounded-lg p-6">
+              <h2 className="text-xl font-semibold mb-4">バックテスト設定</h2>
+              <BacktestForm
+                onSubmit={handleRunBacktest}
+                isLoading={backtestLoading}
+              />
+            </div>
+
+            {/* 最新結果のプレビュー */}
+            {latestResult && (
+              <div className="bg-gray-800 rounded-lg p-6">
+                <h2 className="text-xl font-semibold mb-4">最新結果</h2>
+                <PerformanceMetrics result={latestResult} />
+              </div>
+            )}
           </div>
-        </div>
 
-        {/* コンテンツ */}
-        <div className="space-y-6">
-          {activeTab === "form" && (
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              {/* バックテスト設定フォーム */}
-              <div className="bg-gray-800 rounded-lg p-6">
-                <h2 className="text-xl font-semibold mb-4">バックテスト設定</h2>
-                <BacktestForm
-                  onSubmit={handleRunBacktest}
-                  isLoading={backtestLoading}
-                />
+          {/* 右側: 結果一覧と詳細 */}
+          <div className="space-y-6">
+            {/* 結果一覧テーブル */}
+            <div className="bg-gray-800 rounded-lg p-6">
+              <div className="flex justify-between items-center mb-4">
+                <h2 className="text-xl font-semibold">
+                  バックテスト結果一覧
+                </h2>
+                <button
+                  onClick={loadResults}
+                  disabled={resultsLoading}
+                  className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                >
+                  {resultsLoading ? "読み込み中..." : "更新"}
+                </button>
               </div>
-
-              {/* 最新結果のプレビュー */}
-              {latestResult && (
-                <div className="bg-gray-800 rounded-lg p-6">
-                  <h2 className="text-xl font-semibold mb-4">最新結果</h2>
-                  <PerformanceMetrics result={latestResult} />
-                </div>
-              )}
+              <BacktestResultsTable
+                results={results}
+                loading={resultsLoading}
+                onResultSelect={handleResultSelect}
+                onDelete={handleDeleteResult}
+              />
             </div>
-          )}
 
-          {activeTab === "results" && (
-            <div className="space-y-6">
-              {/* 結果一覧テーブル */}
+            {/* 選択された結果の詳細 */}
+            {selectedResult && (
               <div className="bg-gray-800 rounded-lg p-6">
-                <div className="flex justify-between items-center mb-4">
-                  <h2 className="text-xl font-semibold">
-                    バックテスト結果一覧
-                  </h2>
-                  <button
-                    onClick={loadResults}
-                    disabled={resultsLoading}
-                    className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
-                  >
-                    {resultsLoading ? "読み込み中..." : "更新"}
-                  </button>
-                </div>
-                <BacktestResultsTable
-                  results={results}
-                  loading={resultsLoading}
-                  onResultSelect={handleResultSelect}
-                  onDelete={handleDeleteResult}
-                />
+                <h2 className="text-xl font-semibold mb-4">
+                  結果詳細 - {selectedResult.strategy_name}
+                </h2>
+                <PerformanceMetrics result={selectedResult} />
               </div>
-
-              {/* 選択された結果の詳細 */}
-              {selectedResult && (
-                <div className="bg-gray-800 rounded-lg p-6">
-                  <h2 className="text-xl font-semibold mb-4">
-                    結果詳細 - {selectedResult.strategy_name}
-                  </h2>
-                  <PerformanceMetrics result={selectedResult} />
-                </div>
-              )}
-            </div>
-          )}
+            )}
+          </div>
         </div>
 
         {/* ローディング状態 */}


### PR DESCRIPTION
## 🎯 概要

バックテストページのレイアウトを改善し、タブ切り替えから左右分割表示に変更しました。

## 🔄 変更内容

### UI/UX改善
- **タブナビゲーションを削除**: 「バックテスト設定」と「結果一覧」のタブ切り替えを廃止
- **2カラムレイアウト実装**: 左側に設定フォーム、右側に結果表示を固定配置
- **同時表示**: 設定変更と結果確認を同時に行える効率的なワークフロー

### 技術的変更
- `activeTab` stateの削除
- レイアウトを`xl:grid-cols-2`による2カラムグリッドに変更
- レスポンシブデザインの維持（XL未満では縦積み表示）

## 📱 レスポンシブ対応

- **XL以上 (1280px+)**: 2カラム表示
- **XL未満**: 縦積み表示（モバイル・タブレット対応）

## 🎉 改善されたUX

1. **効率的な作業フロー**: タブ切り替えが不要
2. **直感的な操作**: 左で設定、右で結果確認という自然な流れ
3. **スペース活用**: 画面の右側スペースを有効活用
4. **リアルタイム比較**: 設定を変更しながら結果を即座に確認可能

## 🧪 テスト

- [x] デスクトップでの2カラム表示確認
- [x] モバイル・タブレットでの縦積み表示確認
- [x] バックテスト実行時の動作確認
- [x] 結果選択・削除機能の動作確認

## 📸 変更前後の比較

**変更前**: タブ切り替え式
- 設定と結果を別々のタブで表示
- タブ切り替えが必要

**変更後**: 左右分割表示
- 設定と結果を同時表示
- 効率的なワークフロー

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author