### PR TITLE
Refactor: Remove unused imports from backend code

### DIFF
--- a/backend/app/core/services/auto_strategy/engines/ga_engine.py
+++ b/backend/app/core/services/auto_strategy/engines/ga_engine.py
@@ -12,10 +12,9 @@ from typing import List, Dict, Any, Callable, Optional, Tuple
 import logging
 import numpy as np
 
-from deap import base, creator, tools, algorithms
+from deap import base, creator, tools
 
 from ..models.strategy_gene import (
-    StrategyGene,
     encode_gene_to_list,
     decode_list_to_gene,
 )

--- a/backend/app/core/services/auto_strategy/factories/strategy_factory.py
+++ b/backend/app/core/services/auto_strategy/factories/strategy_factory.py
@@ -5,14 +5,13 @@ StrategyGeneから動的にbacktesting.py互換のStrategy継承クラスを生�
 既存のTALibAdapterとの統合を重視した実装です。
 """
 
-from typing import Type, Dict, Any, List, Tuple
+from typing import Type, List, Tuple
 import logging
 import pandas as pd
 import numpy as np
 from backtesting import Strategy
 
 from ..models.strategy_gene import StrategyGene, IndicatorGene, Condition
-from app.core.services.indicators.talib_adapter import TALibAdapter
 from app.core.services.indicators.adapters.trend_adapter import TrendAdapter
 from app.core.services.indicators.adapters.momentum_adapter import MomentumAdapter
 from app.core.services.indicators.adapters.volatility_adapter import VolatilityAdapter

--- a/backend/app/core/services/auto_strategy/models/strategy_gene.py
+++ b/backend/app/core/services/auto_strategy/models/strategy_gene.py
@@ -6,7 +6,7 @@ v1仕様: 最大5指標、単純比較条件のみ
 """
 
 from dataclasses import dataclass, field
-from typing import List, Dict, Any, Union, Optional
+from typing import List, Dict, Any, Union
 import json
 import logging
 

--- a/backend/app/core/services/enhanced_backtest_service.py
+++ b/backend/app/core/services/enhanced_backtest_service.py
@@ -8,8 +8,8 @@ scipyなどの外部ライブラリは不要で、backtesting.py単体で高度�
 import pandas as pd
 import numpy as np
 from datetime import datetime
-from typing import Dict, Any, List, Tuple, Callable, Optional, Union
-from backtesting import Backtest, Strategy
+from typing import Dict, Any, List, Tuple, Callable, Union
+from backtesting import Backtest
 from backtesting.lib import plot_heatmaps
 
 from .backtest_service import BacktestService

--- a/backend/app/core/services/funding_rate_service.py
+++ b/backend/app/core/services/funding_rate_service.py
@@ -5,13 +5,9 @@ CCXTライブラリを使用してBybitからファンディングレートデ�
 データベースに保存する機能を提供します。
 """
 
-import asyncio
-import ccxt
-from datetime import datetime, timezone, timedelta
 from typing import List, Dict, Any, Optional, Callable
 import logging
 
-from database.connection import SessionLocal
 from database.repositories.funding_rate_repository import FundingRateRepository
 from app.core.utils.data_converter import FundingRateDataConverter
 from app.core.services.base_bybit_service import BaseBybitService

--- a/backend/app/core/services/historical_data_service.py
+++ b/backend/app/core/services/historical_data_service.py
@@ -6,7 +6,7 @@
 
 import asyncio
 import logging
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 from app.core.services.market_data_service import BybitMarketDataService

--- a/backend/app/core/services/indicators/abstract_indicator.py
+++ b/backend/app/core/services/indicators/abstract_indicator.py
@@ -5,9 +5,7 @@
 """
 
 import pandas as pd
-import numpy as np
 from abc import ABC, abstractmethod
-from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional, Union
 import logging
 
@@ -44,7 +42,6 @@ class BaseIndicator(ABC):
         Returns:
             計算結果（Series または DataFrame）
         """
-        pass
 
     def validate_data(self, df: pd.DataFrame, min_periods: int) -> None:
         """

--- a/backend/app/core/services/indicators/adapters/base_adapter.py
+++ b/backend/app/core/services/indicators/adapters/base_adapter.py
@@ -5,7 +5,6 @@ TA-Lib アダプター基底クラス
 データ変換、入力検証、エラーハンドリングなどの共通処理を担当します。
 """
 
-import talib
 import pandas as pd
 import numpy as np
 from typing import Union
@@ -17,7 +16,6 @@ logger = logging.getLogger(__name__)
 class TALibCalculationError(Exception):
     """TA-Lib計算エラー"""
 
-    pass
 
 
 class BaseAdapter:

--- a/backend/app/core/services/indicators/indicator_orchestrator.py
+++ b/backend/app/core/services/indicators/indicator_orchestrator.py
@@ -4,12 +4,9 @@
 分割されたテクニカル指標クラスを統合し、既存APIとの互換性を維持します。
 """
 
-import asyncio
 import logging
 from typing import List, Dict, Any, Optional
-from datetime import datetime, timezone
 
-from database.connection import SessionLocal
 
 
 from .trend_indicators import get_trend_indicator, TREND_INDICATORS_INFO

--- a/backend/app/core/services/indicators/momentum_indicators.py
+++ b/backend/app/core/services/indicators/momentum_indicators.py
@@ -5,12 +5,11 @@ RSI、ストキャスティクス、CCI、Williams %R、モメンタム、ROC �
 """
 
 import pandas as pd
-import numpy as np
-from typing import List, Dict, Any, Optional, Union
+from typing import List, Dict, Any, Optional
 import logging
 
 from .abstract_indicator import BaseIndicator
-from .adapters import MomentumAdapter, TALibCalculationError
+from .adapters import MomentumAdapter
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/core/services/indicators/other_indicators.py
+++ b/backend/app/core/services/indicators/other_indicators.py
@@ -5,8 +5,6 @@ PSAR（Parabolic SAR）の実装を提供します。
 """
 
 import pandas as pd
-import numpy as np
-from typing import List, Dict, Any, Optional, Union
 
 from .abstract_indicator import BaseIndicator
 

--- a/backend/app/core/services/indicators/talib_adapter.py
+++ b/backend/app/core/services/indicators/talib_adapter.py
@@ -9,7 +9,7 @@ pandas SeriesとTA-Lib間のデータ変換、エラーハンドリング、
 import talib
 import pandas as pd
 import numpy as np
-from typing import Union, Dict, Any, Optional, List
+from typing import Union, Dict
 import logging
 
 logger = logging.getLogger(__name__)
@@ -18,7 +18,6 @@ logger = logging.getLogger(__name__)
 class TALibCalculationError(Exception):
     """TA-Lib計算エラー"""
 
-    pass
 
 
 class TALibAdapter:

--- a/backend/app/core/services/indicators/trend_indicators.py
+++ b/backend/app/core/services/indicators/trend_indicators.py
@@ -5,12 +5,11 @@ SMA（単純移動平均）、EMA（指数移動平均）、MACD の実装を提
 """
 
 import pandas as pd
-import numpy as np
-from typing import List, Dict, Any, Optional, Union
+from typing import List, Dict, Any, Optional
 import logging
 
 from .abstract_indicator import BaseIndicator
-from .adapters import TrendAdapter, MomentumAdapter, TALibCalculationError
+from .adapters import TrendAdapter, MomentumAdapter
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/core/services/indicators/volatility_indicators.py
+++ b/backend/app/core/services/indicators/volatility_indicators.py
@@ -5,12 +5,11 @@
 """
 
 import pandas as pd
-import numpy as np
-from typing import List, Dict, Any, Optional, Union
+from typing import List, Dict, Any, Optional
 import logging
 
 from .abstract_indicator import BaseIndicator
-from .adapters import VolatilityAdapter, TALibCalculationError
+from .adapters import VolatilityAdapter
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/core/services/indicators/volume_indicators.py
+++ b/backend/app/core/services/indicators/volume_indicators.py
@@ -5,12 +5,11 @@ OBV、Chaikin A/D Line、Chaikin A/D Oscillator の実装を提供します。
 """
 
 import pandas as pd
-import numpy as np
-from typing import List, Dict, Any, Optional, Union
+from typing import List, Dict, Any, Optional
 import logging
 
 from .abstract_indicator import BaseIndicator
-from .adapters import VolumeAdapter, TALibCalculationError
+from .adapters import VolumeAdapter
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/core/services/market_data_service.py
+++ b/backend/app/core/services/market_data_service.py
@@ -11,7 +11,6 @@ CCXT ライブラリを使用してBybit取引所からOHLCVデータを取得�
 import asyncio
 import ccxt
 from typing import List, Optional
-from datetime import datetime, timezone
 import logging
 
 from app.config.market_config import MarketDataConfig

--- a/backend/app/core/services/open_interest_service.py
+++ b/backend/app/core/services/open_interest_service.py
@@ -8,9 +8,8 @@ Bybitオープンインタレストサービス
 import asyncio
 import logging
 from datetime import datetime, timezone
-from typing import Dict, List, Optional, Any, Callable
+from typing import Dict, List, Optional, Any
 
-import ccxt
 from database.connection import SessionLocal
 
 # OpenInterestDataは循環インポートを避けるため、必要時にインポート

--- a/backend/app/core/services/strategy_showcase_service.py
+++ b/backend/app/core/services/strategy_showcase_service.py
@@ -5,12 +5,10 @@
 """
 
 import logging
-import random
 from typing import List, Dict, Any, Optional
-from sqlalchemy.orm import Session
-from datetime import datetime, timedelta
+from datetime import datetime
 
-from database.models import StrategyShowcase, BacktestResult
+from database.models import StrategyShowcase
 from database.connection import get_db
 
 logger = logging.getLogger(__name__)

--- a/backend/app/core/strategies/base_strategy.py
+++ b/backend/app/core/strategies/base_strategy.py
@@ -31,7 +31,6 @@ class BaseStrategy(Strategy, ABC):
         戦略で使用するテクニカル指標を初期化します。
         各戦略で実装が必要です。
         """
-        pass
 
     @abstractmethod
     def next(self):
@@ -41,7 +40,6 @@ class BaseStrategy(Strategy, ABC):
         各バーで実行される売買判定ロジックです。
         各戦略で実装が必要です。
         """
-        pass
 
     def get_strategy_info(self) -> Dict[str, Any]:
         """

--- a/backend/app/core/strategies/macd_strategy.py
+++ b/backend/app/core/strategies/macd_strategy.py
@@ -8,7 +8,6 @@ MACDラインとシグナルラインのクロスオーバーを利用したト�
 from backtesting import Strategy
 from backtesting.lib import crossover
 from .indicators import MACD, SMA
-from .base_strategy import BaseStrategy
 
 
 class MACDStrategy(Strategy):

--- a/backend/app/core/strategies/risk_management/base.py
+++ b/backend/app/core/strategies/risk_management/base.py
@@ -4,7 +4,7 @@
 backtesting.pyの組み込みSL/TP機能を活用したMixinクラス
 """
 
-from typing import Optional, Dict, Any, Union
+from typing import Optional, Dict, Any
 import logging
 from .calculators import RiskCalculator, calculate_sl_tp_prices
 from .validators import validate_risk_parameters

--- a/backend/app/core/strategies/risk_management/validators.py
+++ b/backend/app/core/strategies/risk_management/validators.py
@@ -4,7 +4,7 @@
 リスク管理設定の妥当性を検証する機能
 """
 
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, Optional
 import logging
 
 logger = logging.getLogger(__name__)

--- a/backend/app/core/strategies/rsi_strategy.py
+++ b/backend/app/core/strategies/rsi_strategy.py
@@ -7,7 +7,6 @@ RSIの過買い・過売りレベルを利用した逆張り戦略
 
 from backtesting import Strategy
 from .indicators import RSI
-from .base_strategy import BaseStrategy
 
 
 class RSIStrategy(Strategy):

--- a/backend/app/core/strategies/sma_cross_strategy.py
+++ b/backend/app/core/strategies/sma_cross_strategy.py
@@ -8,7 +8,6 @@ Simple Moving Average Crossover Strategy
 from backtesting import Strategy
 from backtesting.lib import crossover
 from .indicators import SMA
-from .base_strategy import BaseStrategy
 
 
 class SMACrossStrategy(Strategy):

--- a/backend/app/core/utils/database_utils.py
+++ b/backend/app/core/utils/database_utils.py
@@ -2,10 +2,9 @@
 データベース操作の共通ユーティリティ
 """
 
-from typing import List, Any, Type
+from typing import List, Type
 from sqlalchemy.orm import Session
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy import Table
 import logging
 
 logger = logging.getLogger(__name__)

--- a/backend/scripts/check_available_symbols.py
+++ b/backend/scripts/check_available_symbols.py
@@ -9,7 +9,7 @@ Bybitで利用可能なシンボルを確認するスクリプト
 import asyncio
 import ccxt
 import logging
-from typing import Dict, List, Set
+from typing import Dict, List
 from app.config.market_config import MarketDataConfig
 
 # ログ設定

--- a/backend/scripts/check_database_status.py
+++ b/backend/scripts/check_database_status.py
@@ -7,7 +7,6 @@
 
 import sys
 import os
-from datetime import datetime, timedelta, timezone
 import logging
 
 # プロジェクトルートをパスに追加

--- a/backend/scripts/clear_ohlcv_data.py
+++ b/backend/scripts/clear_ohlcv_data.py
@@ -8,7 +8,6 @@ OHLCVデータクリアスクリプト
 import logging
 import sys
 import os
-from typing import Optional
 
 # プロジェクトルートをパスに追加
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/backend/scripts/collect_btcusdt_multi_timeframe.py
+++ b/backend/scripts/collect_btcusdt_multi_timeframe.py
@@ -9,7 +9,6 @@ import asyncio
 import logging
 import sys
 import os
-from datetime import datetime, timezone, timedelta
 from typing import List
 
 # プロジェクトルートをパスに追加
@@ -18,7 +17,6 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from database.connection import SessionLocal, init_db
 from database.repositories.ohlcv_repository import OHLCVRepository
 from data_collector.collector import DataCollector
-from app.core.services.market_data_service import BybitMarketDataService
 from app.config.market_config import MarketDataConfig
 
 # ログ設定

--- a/backend/scripts/create_sample_data.py
+++ b/backend/scripts/create_sample_data.py
@@ -8,7 +8,7 @@ import sys
 import os
 import pandas as pd
 import numpy as np
-from datetime import datetime, timedelta
+from datetime import datetime
 import logging
 
 # プロジェクトルートをパスに追加

--- a/backend/scripts/generate_full_strategies.py
+++ b/backend/scripts/generate_full_strategies.py
@@ -1,5 +1,4 @@
 import requests
-import json
 import time
 
 

--- a/backend/scripts/run_real_ga_strategy.py
+++ b/backend/scripts/run_real_ga_strategy.py
@@ -21,7 +21,6 @@ from database.repositories.open_interest_repository import OpenInterestRepositor
 from database.repositories.funding_rate_repository import FundingRateRepository
 from app.core.services.backtest_data_service import BacktestDataService
 from app.core.services.auto_strategy.generators.random_gene_generator import RandomGeneGenerator
-from app.core.services.auto_strategy.models.strategy_gene import StrategyGene
 
 # ログ設定
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')

--- a/backend/scripts/run_simple_ga_demo.py
+++ b/backend/scripts/run_simple_ga_demo.py
@@ -13,7 +13,7 @@ import json
 import time
 import random
 from dataclasses import dataclass
-from typing import List, Dict, Union, Any
+from typing import List, Dict, Union
 import uuid
 
 # プロジェクトルートをパスに追加

--- a/backend/scripts/simple_data_check.py
+++ b/backend/scripts/simple_data_check.py
@@ -7,7 +7,6 @@
 
 import sys
 import os
-from datetime import datetime, timedelta, timezone
 import logging
 
 # プロジェクトルートをパスに追加

--- a/backend/scripts/verify_persistence.py
+++ b/backend/scripts/verify_persistence.py
@@ -6,7 +6,6 @@
 
 import sys
 import os
-from datetime import datetime
 
 # プロジェクトルートをパスに追加
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))


### PR DESCRIPTION
I've automatically removed unused imports from Python files in the backend/app and backend/scripts directories.

This helps to keep the codebase clean and reduce potential confusion. I skipped running the full test suite due to timeout issues with TA-Lib installation in the CI environment.